### PR TITLE
Fix: Correct hadith data and refactor auto-read logic

### DIFF
--- a/src/components/HadithReader.tsx
+++ b/src/components/HadithReader.tsx
@@ -79,20 +79,17 @@ export const HadithReader = () => {
       setSelectedBook(bookSlug);
       setHadithNumber(num);
       fetchHadith(bookSlug, num);
-      
-      // Auto-read if enabled
-      if (settings.autoRead && isSupported) {
-        setTimeout(() => {
-          fetchHadith(bookSlug, num).then(() => {
-            // Auto-speak after hadith loads
-          });
-        }, 1000);
-      }
     } else if (!bookSlug) {
       // If no book is selected in the URL, default to Bukhari
       navigate('/read/Bukhari/1', { replace: true });
     }
-  }, [bookSlug, hadithNumberStr, toast, navigate, settings.autoRead, isSupported]);
+  }, [bookSlug, hadithNumberStr, toast, navigate]);
+
+  useEffect(() => {
+    if (hadith && settings.autoRead && isSupported) {
+      speak(hadith.bn, 'bn-BD');
+    }
+  }, [hadith, settings.autoRead, isSupported, speak]);
 
   const handleBookSelect = (slug: string) => {
     setSelectedBook(slug);

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -33,7 +33,7 @@ export const HomePage = () => {
 
   const books = [
     { name: 'সহীহ বুখারী', nameAr: 'صحيح البخاري', hadithCount: '৭,৫৬৩' },
-    { name: 'সহীহ মুসলিম', nameAr: 'صحيح مسلم', hadithCount: '৭,৫৬ৃ' },
+    { name: 'সহীহ মুসলিম', nameAr: 'صحيح مسلم', hadithCount: '৭,৫৬৩' },
     { name: 'সুনান আবু দাউদ', nameAr: 'سنن أبي داود', hadithCount: '৫,২৭৪' },
     { name: 'সুনান ইবনে মাজাহ', nameAr: 'سنن ابن ماجه', hadithCount: '৪,৩৪১' },
     { name: 'সুনান আন-নাসাঈ', nameAr: 'سنن النسائي', hadithCount: '৫,৭৫৮' },


### PR DESCRIPTION
This commit addresses two bugs in the application:

1.  **Fix hadith count typo:** The hadith count for Sahih Muslim on the home page contained a typo ('৭,৫৬ৃ' instead of '৭,৫৬৩'). This has been corrected to ensure data consistency.

2.  **Refactor auto-read logic:** The auto-read functionality in the HadithReader component was flawed. It made a duplicate API call and the text-to-speech was not triggered. This has been refactored to remove the redundant API call and correctly trigger the text-to-speech functionality after the hadith data is loaded. This improves performance and fixes the bug.