### PR TITLE
Fix: Rearchitect settings state management to fix font switching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "next-themes";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { useSettings } from "@/hooks/useSettings";
+import { useSettings, SettingsProvider } from "@/hooks/useSettings";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import { HomePage } from "./components/HomePage";
@@ -33,10 +33,11 @@ const FontManager = () => {
 const App = () => (
   <ErrorBoundary>
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
-        <TooltipProvider>
-          <FontManager />
-          <Toaster />
+      <SettingsProvider>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          <TooltipProvider>
+            <FontManager />
+            <Toaster />
           <Sonner />
           <BrowserRouter>
             <Routes>
@@ -56,6 +57,7 @@ const App = () => (
           </BrowserRouter>
         </TooltipProvider>
       </ThemeProvider>
+      </SettingsProvider>
     </QueryClientProvider>
   </ErrorBoundary>
 );

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, createContext, useContext, ReactNode } from 'react';
 
 export interface AppSettings {
   fontSize: 'small' | 'medium' | 'large';
@@ -20,7 +20,14 @@ const DEFAULT_SETTINGS: AppSettings = {
 
 const SETTINGS_KEY = 'hadith_app_settings';
 
-export const useSettings = () => {
+interface SettingsContextType {
+  settings: AppSettings;
+  updateSettings: (newSettings: Partial<AppSettings>) => void;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const SettingsProvider = ({ children }: { children: ReactNode }) => {
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
 
   useEffect(() => {
@@ -46,5 +53,17 @@ export const useSettings = () => {
     });
   }, []);
 
-  return { settings, updateSettings };
+  return (
+    <SettingsContext.Provider value={{ settings, updateSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (context === undefined) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
 };


### PR DESCRIPTION
This commit fixes a persistent and critical bug where font changes in the settings were not being applied in real-time.

The root cause was that different components were using separate, un-synced instances of the settings state.

This has been resolved by refactoring the state management to use the React Context API. A new `SettingsProvider` now wraps the entire application, providing a single, shared source of truth for all settings. This ensures that any update to the settings is instantly reflected across all components, including the `FontManager` which applies the font styles.

- Refactored `useSettings.ts` to create and export a `SettingsProvider` and `SettingsContext`.
- Wrapped the application in `SettingsProvider` in `App.tsx`.
- Renamed `useSettings.ts` to `useSettings.tsx` to resolve a linter parsing issue with TypeScript generics.